### PR TITLE
Update builder.py

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -260,7 +260,10 @@ def clean_loader():
 
 def clean_output():
     output_dir = f"{os.getcwd()}\output"
-    shutil.rmtree(output_dir)
+    try:
+        shutil.rmtree(output_dir)
+    except:
+        pass
     os.makedirs(output_dir)
 
 


### PR DESCRIPTION
PR to include a try/except around the remove dir line in the clean_output function.

Fixes an error caused by trying to remove a file that doesn't exist on first run.